### PR TITLE
Removed outdated banners and overhauled UD statistics

### DIFF
--- a/src/api/getStats.ts
+++ b/src/api/getStats.ts
@@ -1,0 +1,51 @@
+
+function validateResolverKeyRegex(key) {
+    const TICKER_REGEX = '[0-9A-Za-z*$+-]+';
+    const ADDRESS_REGEX = new RegExp(`^crypto\.${TICKER_REGEX}\.address$`);
+    const MULTI_CHAIN_ADDRESS_REGEX = new RegExp(
+    `^crypto\.${TICKER_REGEX}\.version\.${TICKER_REGEX}\.address$`,
+    );
+
+    return key.match(ADDRESS_REGEX) || key.match(MULTI_CHAIN_ADDRESS_REGEX)
+}
+
+export const getStats = async () => {
+    try {
+      
+      var res = await fetch('https://raw.githubusercontent.com/unstoppabledomains/uns/main/resolver-keys.json')
+      var json = await res.json()
+      const unsTickers: string[] = []
+      Object.keys(json.keys).forEach(function(key) {
+          if (validateResolverKeyRegex(key)) unsTickers.push(key.split('.')[1])
+      })
+      const uniqueArray = unsTickers.filter(function(item, pos) {
+          return unsTickers.indexOf(item) == pos;
+      })
+      const tickerCount = uniqueArray.length.toLocaleString()
+
+      var res = await fetch('https://unstoppabledomains.com/api/domains/taken-count')
+      var json = await res.json()
+      const takenDomainsCount = (json.takenDomainsCount/1000000).toLocaleString()+'M+'
+
+      var res = await fetch('https://unstoppabledomains.com/api/domain/records/count')
+      var json = await res.json()
+      const recordsCount = Math.round(json.count/1000).toLocaleString()+(json.count/1000 % 1 >= 0.5 ? 'k+' : 'k')
+
+      return {
+        'tickers': tickerCount,
+        'domains': takenDomainsCount,
+        'records': recordsCount, 
+        'integrations': '865',
+        'partners': '1000'
+      }
+    } catch (err) {
+      //console.warn(err)
+      return {
+        'tickers': '307',
+        'domains': '3.8M+',
+        'records': '778k', 
+        'integrations': '865',
+        'partners': '1000'
+      }
+    }
+  }

--- a/src/components/carousel/Carousel.tsx
+++ b/src/components/carousel/Carousel.tsx
@@ -38,20 +38,6 @@ const Carousel: React.FC<PropType> = (props) => {
 */
   const bannerData = [
     {
-      "image": "https://storage.googleapis.com/unstoppable-client-assets-staging/campaigns/Unstoppable%20Marketplace/carousel-unstoppable-premium.png",
-      "utm": 'https://unstoppableweb.co/3RseQPL',
-      "title": "First Ever .Unstoppable Premium Drop",
-      "subtitle": "Single-digit, single-letter and two-letter .Unstoppable domains are available for the very first time. 72 hours only!",
-      "button": 'Shop the Drop'
-    },
-    {
-      "image": "https://storage.googleapis.com/unstoppable-client-assets-staging/campaigns/Unstoppable%20Marketplace/carousel-pudgy.png",
-      "utm": 'https://unstoppableweb.co/3T5IkoZ',
-      "title": "$200 in UD Credit for Pudgy Penguin Holders",
-      "subtitle": "Pudgy Penguin holders can unlock $200 in Unstoppable Credit per penguin owned. Hurry, offer ends soon.",
-      "button": 'Get Credits'
-    },
-    {
       "image": "https://storage.googleapis.com/unstoppable-client-assets-staging/campaigns/Unstoppable%20Marketplace/carousel-unstoppable-tld.png",
       "utm": 'https://unstoppableweb.co/3RsPPoP',
       "title": "It's time! Be .unstoppable today",

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -23,6 +23,7 @@ import { FeaturedCard, SliderButton } from "./card";
 
 import Carousel from "./carousel/Carousel";
 import { EmblaOptionsType } from "embla-carousel-react";
+import { getStats } from "../api/getStats";
 
 
 function NavBar(props) {
@@ -526,6 +527,12 @@ export default function Layout(props) {
     const app = useSelector(getApp);
     const router = useRouter();
     const { data, isLoading } = useGetFeaturedDappsQuery();
+    const [ tickers, setTickers ] = useState<string>('307');
+    const [ takenDomains, setTakenDomains ] = useState<string>('3.8M+');
+    const [ records, setRecords ] = useState<string>('778k');
+    const [ integrations, setIntegrations ] = useState<string>('865');
+    const [ partners, setPartners ] = useState<string>('1000');
+   
     const slider = createRef<Slider>();
     let dragging = false;
     const settings = {
@@ -556,22 +563,38 @@ export default function Layout(props) {
 
     const metrics = [
         {
-          title: 3800000,
+          title: takenDomains,
           description: "Domains Registered",
         },
         {
-          title: 307,
+          title: records,
+          description: "Domain Records Set",
+        },
+        {
+          title: tickers,
           description: "Coins + Tokens Supported",
         },
         {
-          title: 865,
+          title: integrations,
           description: "Integrations",
         },
         {
-          title: 1000,
+          title: partners,
           description: "Partners",
         },
       ];
+
+
+    useEffect(() => {
+        getStats()
+        .then(stats => {
+            setTickers(stats.tickers)
+            setTakenDomains(stats.domains)
+            setRecords(stats.records)
+            setIntegrations(stats.integrations)
+            setPartners(stats.partners)
+        })
+    }, [])
 
     function buildLoadingCard(number: number) {
         let output = Array<React.JSX.Element>();
@@ -682,12 +705,10 @@ export default function Layout(props) {
 
                         <div id="stats" className="bg-white mt-10 w-full">
                             <div className="mx-auto w-[75%] max-w-[1344px] justify-center flex flex-col md:flex-row pt-10 pb-10 md:pt-24 md:pb-24">
-                                {metrics.map((metric, i) => (
+                                {metrics.map((metric) => (
                                 <div className="text-center flex flex-col mx-auto md:pr-4 md:pl-4" key={metric.description}>
                                     <div className="font-[900] md:text-[3rem] lg:text-[4.5rem] text-[2rem] mb-1 text-slate-900">
-                                        {i === 0 ? 
-                                        (parseInt(`${metric.title}`, 10).toLocaleString() + '+') 
-                                        : parseInt(`${metric.title}`, 10).toLocaleString()}
+                                        {`${metric.title}`}
                                     </div>
                                     <div className="text-[1.25rem] text-slate-900">{metric.description}</div>
                                 </div>


### PR DESCRIPTION
Used the same endpoints as ud.com for statistics to keep things synchronized. 
Old:
![Screenshot 2024-01-08 at 3 27 53 PM](https://github.com/unstoppabledomains/unstoppable-domains-marketplace/assets/28935974/47b616ac-a5eb-41b3-aa46-516da68c1c5f)
New:
![Screenshot 2024-01-08 at 3 27 43 PM](https://github.com/unstoppabledomains/unstoppable-domains-marketplace/assets/28935974/4c12e4c4-3720-4312-9799-2bd91463a89b)

Also removed 2 banners relating to completed campaigns.